### PR TITLE
chore: configure Claude Code datum plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "extraKnownMarketplaces": {
+    "datum-claude-code-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "datum-cloud/claude-code-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "datum-platform@datum-claude-code-plugins": true,
+    "datum-gtm@datum-claude-code-plugins": true
+  }
+}


### PR DESCRIPTION
This PR configures Claude Code to automatically include the datum-cloud plugins from the shared plugin marketplace.

## Changes
- Adds `.claude/settings.json` with the datum-cloud plugin marketplace configuration
- Enables both `datum-platform` and `datum-gtm` plugins by default

## Settings Added
```json
{
  "extraKnownMarketplaces": {
    "datum-claude-code-plugins": {
      "source": {
        "source": "github",
        "repo": "datum-cloud/claude-code-plugins"
      }
    }
  },
  "enabledPlugins": {
    "datum-platform@datum-claude-code-plugins": true,
    "datum-gtm@datum-claude-code-plugins": true
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)