### PR TITLE
chore: name real code owners for this repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,24 @@
-* @datumforge/blacksmiths
+# Code owners for datum-cloud/.github.
+#
+# This repository is not a normal service repository. Most of what it holds is
+# inherited by every other repository in the organization as a default community
+# health file, so a change here changes what contributors see org-wide.
+#
+# GitHub applies the LAST matching rule, so the catch-all comes first and the
+# specific paths below it win.
+#
+# Note: an organization cannot supply a default CODEOWNERS. This file governs
+# this repository only. Per-repository coverage is tracked separately.
+
+* @datum-cloud/engineering
+
+# Public organization landing page — marketing content, not engineering.
+/profile/ @datum-cloud/gtm
+
+# Contribution, licensing and security policy. These carry legal and disclosure
+# commitments and should not be reviewed by whoever is next in the rotation.
+/CLA.md             @ecv
+/CONTRIBUTING.md    @ecv
+/CODE_OF_CONDUCT.md @ecv
+/SECURITY.md        @ecv
+/LICENSE            @ecv

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,10 +15,12 @@
 # Public organization landing page — marketing content, not engineering.
 /profile/ @datum-cloud/gtm
 
-# Contribution, licensing and security policy. These carry legal and disclosure
-# commitments and should not be reviewed by whoever is next in the rotation.
+# How vulnerabilities are reported to us.
+/SECURITY.md        @datum-cloud/security
+
+# Contribution and licensing commitments. These are legal text and should not be
+# reviewed by whoever is next in the rotation.
 /CLA.md             @ecv
 /CONTRIBUTING.md    @ecv
 /CODE_OF_CONDUCT.md @ecv
-/SECURITY.md        @ecv
 /LICENSE            @ecv


### PR DESCRIPTION
## Summary

Ownership of this repository has pointed at a team in an organization Datum does not control since the repository was inherited, so changes to the policies every other repository inherits have been merging with nobody accountable for them. A rule naming a team that cannot resolve is the worst of the available states, because it reads as ownership while granting none.

This names owners that exist: engineering by default, marketing for the public landing page it already writes elsewhere, and the security team for the disclosure policy. Contribution and licensing terms stay with one person, because legal text is worse served by a rotation than by someone who answers for it.

## Test plan

- [ ] A change to the landing page draws marketing, not engineering
- [ ] A change to the disclosure policy draws the security team
- [ ] A change elsewhere draws the default owner

> [!IMPORTANT]
> Two of these owners have no access to this repository yet, and GitHub drops review requests from teams without write access without reporting an error. Both grants have to land before this merges or the rules will read as correct and assign nobody: https://github.com/datum-cloud/infra/pull/3888 and https://github.com/datum-cloud/infra/pull/3890

Related to datum-cloud/engineering#366, datum-cloud/engineering#368
